### PR TITLE
HTTPS

### DIFF
--- a/lib/hasoffersv3/configuration.rb
+++ b/lib/hasoffersv3/configuration.rb
@@ -14,7 +14,7 @@ class HasOffersV3
 
     DEFAULTS = {
       host: 'api.hasoffers.com',
-      protocol: 'http',
+      protocol: 'https',
       base_path: '/v3',
       network_id: '',
       api_key: '',

--- a/spec/lib/affiliate_offer_spec.rb
+++ b/spec/lib/affiliate_offer_spec.rb
@@ -10,7 +10,7 @@ describe HasOffersV3::AffiliateOffer do
   end
 
   context 'urls' do
-    specify { expect(url).to eq('http://api.hasoffers.com/v3/Affiliate_Offer.json') }
+    specify { expect(url).to eq('https://api.hasoffers.com/v3/Affiliate_Offer.json') }
   end
 
   describe '.find_all' do

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -13,10 +13,10 @@ describe HasOffersV3::Client do
 
     it 'should be different configs' do
       default_connection = HasOffersV3::Client.new(configuration_to_default_host)
-      expect(default_connection.base_uri).to eq('http://api.hasoffers.com/v3')
+      expect(default_connection.base_uri).to eq('https://api.hasoffers.com/v3')
 
       proxy_connection = HasOffersV3::Client.new(config_for_proxy)
-      expect(proxy_connection.base_uri).to eq('http://api.applift.com/v3')
+      expect(proxy_connection.base_uri).to eq('https://api.applift.com/v3')
     end
 
   end


### PR DESCRIPTION
This defaults the gem to use HTTPS when hitting the HasOffers API endpoints. You can still set it back to HTTP manually if you really want to, but this seems like a more reasonable default. Otherwise, we're just sending credentials in the clear.

Maybe I'm missing something though :)