### PR TITLE
Improve and organize tests

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --format documentation
+--require=spec_helper

--- a/hasoffersv3.gemspec
+++ b/hasoffersv3.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport' # for to_param method
   s.add_development_dependency 'webmock'
-  s.add_development_dependency 'rspec',   '~> 3.0.0'
+  s.add_development_dependency 'rspec',   '~> 3.4.0'
   s.add_development_dependency 'bundler', '~> 1.3'
   s.add_development_dependency 'rake'
 end

--- a/spec/lib/advertiser_billing_spec.rb
+++ b/spec/lib/advertiser_billing_spec.rb
@@ -1,11 +1,7 @@
-require 'spec_helper'
-
 describe HasOffersV3::AdvertiserBilling do
-  subject { HasOffersV3::AdvertiserBilling }
-
   let(:url) { api_url 'AdvertiserBilling' }
 
-  describe '.find_all_invoices' do
+  describe '#find_all_invoices' do
     it 'makes a proper request call' do
       stub_call
       response = subject.find_all_invoices
@@ -14,7 +10,7 @@ describe HasOffersV3::AdvertiserBilling do
     end
   end
 
-  describe '.create_invoice' do
+  describe '#create_invoice' do
     context 'when data is specified' do
       it 'makes a proper request call' do
         stub_call
@@ -35,7 +31,7 @@ describe HasOffersV3::AdvertiserBilling do
     end
   end
 
-  describe '.find_invoice_by_id' do
+  describe '#find_invoice_by_id' do
     context 'when ID is specified' do
       it 'makes a proper request call' do
         stub_call
@@ -52,16 +48,16 @@ describe HasOffersV3::AdvertiserBilling do
     end
   end
 
-  describe '.add_invoice_item' do
+  describe '#add_invoice_item' do
     context 'when invoice  ID and data is specified' do
       it 'makes a proper request call' do
         stub_call
         response = subject.add_invoice_item(invoice_id: 1, data: {memo: 'abc'})
-        a_request(:post, url).with(body: hash_including({
+        expect(a_request(:post, url).with(body: hash_including({
           'Method'     => 'addInvoiceItem',
           'invoice_id' => '1',
           'data'       => {'memo' => 'abc'}
-        })).should have_been_made
+        }))).to have_been_made
         validate_call response
       end
     end
@@ -79,12 +75,12 @@ describe HasOffersV3::AdvertiserBilling do
     end
   end
 
-  describe '.remove_invoice_item' do
+  describe '#remove_invoice_item' do
     context 'when ID is specified' do
       it 'makes a proper request call' do
         stub_call
         response = subject.remove_invoice_item(id: '1')
-        a_request(:post, url).with(body: hash_including({'Method' => 'removeInvoiceItem', 'id' => '1'})).should have_been_made
+        expect(a_request(:post, url).with(body: hash_including({'Method' => 'removeInvoiceItem', 'id' => '1'}))).to have_been_made
         validate_call response
       end
     end

--- a/spec/lib/advertiser_spec.rb
+++ b/spec/lib/advertiser_spec.rb
@@ -1,12 +1,8 @@
-require 'spec_helper'
-
 describe HasOffersV3::Advertiser do
-  subject { HasOffersV3::Advertiser.new }
-
   let(:url)  { api_url 'Advertiser' }
 
-  describe '.find_all' do
-    it 'should make a proper request call' do
+  describe '#find_all' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.find_all
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAll'}))).to have_been_made
@@ -14,8 +10,8 @@ describe HasOffersV3::Advertiser do
     end
   end
 
-  describe '.find_all_ids' do
-    it 'should make a proper request call' do
+  describe '#find_all_ids' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.find_all_ids
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAllIds'}))).to have_been_made
@@ -23,8 +19,8 @@ describe HasOffersV3::Advertiser do
     end
   end
 
-  describe '.find_by_id' do
-    it 'should make a proper request call' do
+  describe '#find_by_id' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.find_by_id id: 1
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findById', 'id' => '1'}))).to have_been_made
@@ -32,7 +28,7 @@ describe HasOffersV3::Advertiser do
     end
 
     context 'when there is no id' do
-      it 'should raise exception' do
+      it 'raises exception' do
         expect { subject.find_by_id failed_id: 1 }.to raise_error ArgumentError
       end
     end

--- a/spec/lib/advertiser_user_spec.rb
+++ b/spec/lib/advertiser_user_spec.rb
@@ -1,12 +1,8 @@
-require 'spec_helper'
-
 describe HasOffersV3::AdvertiserUser do
-  subject { HasOffersV3::AdvertiserUser.new }
-
   let(:url)  { api_url 'AdvertiserUser' }
 
-  describe '.find_all' do
-    it 'should make a proper request call' do
+  describe '#find_all' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.find_all
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAll'}))).to have_been_made

--- a/spec/lib/affiliate_billing_spec.rb
+++ b/spec/lib/affiliate_billing_spec.rb
@@ -1,16 +1,12 @@
-require 'spec_helper'
-
 describe HasOffersV3::AffiliateBilling do
-  subject { HasOffersV3::AffiliateBilling.new }
-
   let(:url) { api_url 'AffiliateBilling' }
 
-  describe '.find_last_invoice' do
+  describe '#find_last_invoice' do
     context 'when affiliate ID is specified' do
       it 'makes a proper request call' do
         stub_call
         response = subject.find_last_invoice(affiliate_id: '1')
-        a_request(:post, url).with(body: hash_including({'Method' => 'findLastInvoice', 'affiliate_id' => '1'})).should have_been_made
+        expect(a_request(:post, url).with(body: hash_including({'Method' => 'findLastInvoice', 'affiliate_id' => '1'}))).to have_been_made
         validate_call response
       end
     end
@@ -22,15 +18,15 @@ describe HasOffersV3::AffiliateBilling do
     end
   end
 
-  describe '.create_invoice' do
+  describe '#create_invoice' do
     context 'when data is specified' do
       it 'makes a proper request call' do
         stub_call
         response = subject.create_invoice(data: {affiliate_id: 1, start_date: '2014-10-01', end_date: '2014-10-30'})
-        a_request(:post, url).with(body: hash_including({
+        expect(a_request(:post, url).with(body: hash_including({
           'Method' => 'createInvoice',
           'data'   => {'affiliate_id' => '1', 'start_date' => '2014-10-01', 'end_date' => '2014-10-30'}
-        })).should have_been_made
+        }))).to have_been_made
         validate_call response
       end
     end
@@ -42,12 +38,12 @@ describe HasOffersV3::AffiliateBilling do
     end
   end
 
-  describe '.find_invoice_by_id' do
+  describe '#find_invoice_by_id' do
     context 'when ID is specified' do
       it 'makes a proper request call' do
         stub_call
         response = subject.find_invoice_by_id(id: '1')
-        a_request(:post, url).with(body: hash_including({'Method' => 'findInvoiceById', 'id' => '1'})).should have_been_made
+        expect(a_request(:post, url).with(body: hash_including({'Method' => 'findInvoiceById', 'id' => '1'}))).to have_been_made
         validate_call response
       end
     end
@@ -59,16 +55,16 @@ describe HasOffersV3::AffiliateBilling do
     end
   end
 
-  describe '.add_invoice_item' do
+  describe '#add_invoice_item' do
     context 'when invoice ID and data is specified' do
       it 'makes a proper request call' do
         stub_call
         response = subject.add_invoice_item(invoice_id: 1, data: {memo: 'abc'})
-        a_request(:post, url).with(body: hash_including({
+        expect(a_request(:post, url).with(body: hash_including({
           'Method'     => 'addInvoiceItem',
           'invoice_id' => '1',
           'data'       => {'memo' => 'abc'}
-        })).should have_been_made
+        }))).to have_been_made
         validate_call response
       end
     end
@@ -86,12 +82,12 @@ describe HasOffersV3::AffiliateBilling do
     end
   end
 
-  describe '.remove_invoice_item' do
+  describe '#remove_invoice_item' do
     context 'when ID is specified' do
       it 'makes a proper request call' do
         stub_call
         response = subject.remove_invoice_item(id: '1')
-        a_request(:post, url).with(body: hash_including({'Method' => 'removeInvoiceItem', 'id' => '1'})).should have_been_made
+        expect(a_request(:post, url).with(body: hash_including({'Method' => 'removeInvoiceItem', 'id' => '1'}))).to have_been_made
         validate_call response
       end
     end

--- a/spec/lib/affiliate_offer_spec.rb
+++ b/spec/lib/affiliate_offer_spec.rb
@@ -1,11 +1,7 @@
-require 'spec_helper'
-
 describe HasOffersV3::AffiliateOffer do
-  subject { HasOffersV3::AffiliateOffer.new }
-
   let(:url)  { api_url 'Affiliate_Offer' }
 
-  describe '.target' do
+  describe '#target' do
     specify { expect(subject.target).to eq('Affiliate_Offer')}
   end
 
@@ -13,8 +9,8 @@ describe HasOffersV3::AffiliateOffer do
     specify { expect(url).to eq('https://api.hasoffers.com/v3/Affiliate_Offer.json') }
   end
 
-  describe '.find_all' do
-    it 'should make a proper request call' do
+  describe '#find_all' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.find_all
       request = a_request(:post, url).with(body: hash_including('Method' => 'findAll'))
@@ -23,8 +19,8 @@ describe HasOffersV3::AffiliateOffer do
     end
   end
 
-  describe '.find_by_id' do
-    it 'should make a proper request call' do
+  describe '#find_by_id' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.find_by_id id: 1
       request = a_request(:post, url).with(body: hash_including('Method' => 'findById', 'id' => '1'))
@@ -34,14 +30,14 @@ describe HasOffersV3::AffiliateOffer do
     end
 
     context 'when there is no id' do
-      it 'should raise exception' do
+      it 'raises exception' do
         expect { subject.find_by_id }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.get_categories' do
-    it 'should make a proper request call' do
+  describe '#get_categories' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.get_categories ids: [1, 2]
       request = a_request(:post, url).with(body: hash_including('Method' => 'getCategories'))
@@ -51,14 +47,14 @@ describe HasOffersV3::AffiliateOffer do
     end
 
     context 'when there is no id' do
-      it 'should raise exception' do
+      it 'raises exception' do
         expect { subject.get_categories }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.get_target_countries' do
-    it 'should make a proper request call' do
+  describe '#get_target_countries' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.get_target_countries ids: [1, 2]
       request = a_request(:post, url).with(body: hash_including('Method' => 'getTargetCountries'))
@@ -68,14 +64,14 @@ describe HasOffersV3::AffiliateOffer do
     end
 
     context 'when there is no id' do
-      it 'should raise exception' do
+      it 'raises exception' do
         expect { subject.get_target_countries }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.generate_tracking_link' do
-    it 'should make a proper request call' do
+  describe '#generate_tracking_link' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.generate_tracking_link offer_id: 1
       request = a_request(:post, url).with(body: hash_including('Method' => 'generateTrackingLink'))
@@ -85,14 +81,14 @@ describe HasOffersV3::AffiliateOffer do
     end
 
     context 'when there is no offer_id' do
-      it 'should raise exception' do
+      it 'raises exception' do
         expect { subject.generate_tracking_link }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.find_my_offers' do
-    it 'should make a proper request call' do
+  describe '#find_my_offers' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.find_my_offers
       request = a_request(:post, url).with(body: hash_including('Method' => 'findMyOffers'))

--- a/spec/lib/affiliate_spec.rb
+++ b/spec/lib/affiliate_spec.rb
@@ -1,24 +1,20 @@
-require 'spec_helper'
-
 describe HasOffersV3::Affiliate do
-  subject { HasOffersV3::Affiliate.new }
-
   let(:url)  { api_url 'Affiliate' }
 
   before(:each) do |example|
     stub_call unless example.metadata[:no_stub]
   end
 
-  describe '.find_all' do
-    it 'should make a proper request call' do
+  describe '#find_all' do
+    it 'makes a proper request call' do
       response = subject.find_all
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAll'}))).to have_been_made
       validate_call response
     end
   end
 
-  describe '.find_by_id', :no_stub do
-    it 'should make a proper request call' do
+  describe '#find_by_id', :no_stub do
+    it 'makes a proper request call' do
       stub_call :get, nil, Regexp.new(url)
       response = subject.find_by_id id: 1
       expect(a_request(:get, url).with(query: hash_including({'Method' => 'findById', 'id' => '1'}))).to have_been_made
@@ -26,42 +22,42 @@ describe HasOffersV3::Affiliate do
     end
 
     context 'when there is no id' do
-      it 'should raise exception' do
+      it 'raises exception' do
         expect { subject.find_by_id failed_id: 1 }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.update_payment_method_wire' do
-    it 'should make a proper request call' do
+  describe '#update_payment_method_wire' do
+    it 'makes a proper request call' do
       response = subject.update_payment_method_wire
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'updatePaymentMethodWire'}))).to have_been_made
       validate_call response
     end
   end
 
-  describe '.update_payment_method_paypal' do
-    it 'should make a proper request call' do
+  describe '#update_payment_method_paypal' do
+    it 'makes a proper request call' do
       response = subject.update_payment_method_paypal
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'updatePaymentMethodPaypal'}))).to have_been_made
       validate_call response
     end
   end
 
-  describe 'create' do
+  describe '#create' do
     context 'when required params are missing' do
-      it 'should fail without data' do
+      it 'fails without data' do
         expect { subject.create }.to raise_error ArgumentError
       end
-      it 'should fail without data["company"]' do
+      it 'fails without data["company"]' do
         expect { subject.create data: { zipcode: 1234567 }}.to raise_error ArgumentError
       end
-      it 'should fail without data["zipcode"]' do
+      it 'fails without data["zipcode"]' do
         expect { subject.create data: { company: 'xyz@applift.com' }}.to raise_error ArgumentError
       end
     end
 
-    it 'should make a successful request call' do
+    it 'makes a successful request call' do
       response = subject.create data: { company: "xyz@gmail.com", zipcode: "10178" }
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'create', 'data' => {'company' => 'xyz@gmail.com',
        'zipcode' => '10178'}}))).to have_been_made
@@ -69,15 +65,15 @@ describe HasOffersV3::Affiliate do
     end
   end
 
-  describe '.get_tier' do
-    it 'should make a proper request call' do
+  describe '#get_tier' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.get_tier id: 1
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'getAffiliateTier','id' => '1'}))).to have_been_made
       validate_call response
     end
 
-    it 'should fail without id' do
+    it 'fails without id' do
       expect { subject.get_tier }.to raise_error ArgumentError
     end
   end

--- a/spec/lib/application_spec.rb
+++ b/spec/lib/application_spec.rb
@@ -1,11 +1,8 @@
-require 'spec_helper'
-
 describe HasOffersV3::Application do
   let(:url)  { Regexp.new api_url('Application') }
-  
-  describe '.get_payout_tiers' do
-    subject { HasOffersV3::Application }
-    it 'should make a proper request call' do
+
+  describe '#get_payout_tiers' do
+    it 'makes a proper request call' do
       stub_call :get
       response = subject.get_payout_tiers
       expect(a_request(:get, url).with(query: hash_including({'Method' => 'findAllAffiliateTiers'}))).to have_been_made

--- a/spec/lib/base_spec.rb
+++ b/spec/lib/base_spec.rb
@@ -1,18 +1,14 @@
-require 'spec_helper'
-
 describe HasOffersV3::Base do
-  subject { HasOffersV3::Base }
-
   let(:url) { Regexp.new api_url('Base') }
 
-  describe :requires! do
-    it 'raise ArgumentError is parameters are missing' do
+  describe "#requires!" do
+    it 'raises ArgumentError is parameters are missing' do
       expect { subject.requires!({}, [:dummy]) }.to raise_error(ArgumentError)
     end
   end
 
-  describe ".get_request" do
-    it "should make a proper request" do
+  describe "#get_request" do
+    it "makes a proper request" do
       stub_call :get
       response = subject.get_request 'test'
       request = a_request(:get, url).with(query: hash_including('Method' => 'test'))
@@ -31,7 +27,7 @@ describe HasOffersV3::Base do
         HasOffersV3.configuration.protocol = @old_protocol
       end
 
-      it "should make a proper request" do
+      it "makes a proper request" do
         stub_call :get
         response = subject.get_request 'test'
         expect(a_request(:get, url).with(query: hash_including('Method' => 'test'))).to have_been_made

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HasOffersV3::Client do
 
   describe '#base_uri' do
@@ -11,7 +9,7 @@ describe HasOffersV3::Client do
       result
     }
 
-    it 'should be different configs' do
+    it 'has different configs' do
       default_connection = HasOffersV3::Client.new(configuration_to_default_host)
       expect(default_connection.base_uri).to eq('https://api.hasoffers.com/v3')
 

--- a/spec/lib/conversion_spec.rb
+++ b/spec/lib/conversion_spec.rb
@@ -1,48 +1,31 @@
-require 'spec_helper'
-
 describe HasOffersV3::Conversion do
-  subject { HasOffersV3::Conversion.new }
-
   let(:url)  { Regexp.new api_url('Conversion') }
 
   before :each do
     stub_call :get
   end
 
-  describe '.find_all' do
-    it 'should make a proper request call' do
+  describe '#find_all' do
+    it 'makes a proper request call' do
       response = subject.find_all
       expect(a_request(:get, url).with(query: hash_including({'Method' => 'findAll'}))).to have_been_made
       validate_call response
     end
   end
 
-  describe '.find_added_conversions' do
-    it 'should make a proper request call' do
+  describe '#find_added_conversions' do
+    it 'makes a proper request call' do
       response = subject.find_added_conversions
       expect(a_request(:get, url).with(query: hash_including({'Method' => 'findAddedConversions'}))).to have_been_made
       validate_call response
     end
   end
 
-  describe '.find_updated_conversions' do
-    it 'should make a proper request call' do
+  describe '#find_updated_conversions' do
+    it 'makes a proper request call' do
       response = subject.find_updated_conversions
       expect(a_request(:get, url).with(query: hash_including({'Method' => 'findUpdatedConversions'}))).to have_been_made
       validate_call response
-    end
-  end
-
-  describe '.findAll' do
-    it 'should make a proper request call' do
-      response = subject.find_all
-      expect(a_request(:get, url).with(query: hash_including({'Method' => 'findAll'}))).to have_been_made
-      validate_call response
-    end
-
-    it 'should call find_all method' do
-      expect(subject).to receive(:find_all).with({test: 1})
-      subject.find_all test: 1
     end
   end
 end

--- a/spec/lib/employee_spec.rb
+++ b/spec/lib/employee_spec.rb
@@ -1,45 +1,41 @@
-require 'spec_helper'
-
 describe HasOffersV3::Employee do
-  subject { HasOffersV3::Employee.new }
-
   let(:url)  { api_url 'Employee' }
 
   before(:each) do |example|
     stub_call unless example.metadata[:no_stub]
   end
 
-  describe '.find_all' do
-    it 'should make a proper request call' do
+  describe '#find_all' do
+    it 'makes a proper request call' do
       response = subject.find_all
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAll'}))).to have_been_made
       validate_call response
     end
   end
 
-  describe '.find_all_by_ids' do
-    it 'should make a proper request call' do
+  describe '#find_all_by_ids' do
+    it 'makes a proper request call' do
       response = subject.find_all_by_ids ids: [1]
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAllByIds'}))).to have_been_made
       validate_call response
     end
 
     context 'when there is no id' do
-      it 'should raise exception' do
+      it 'raises exception' do
         expect { subject.find_all_by_ids }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.find_by_id' do
-    it 'should make a proper request call' do
+  describe '#find_by_id' do
+    it 'makes a proper request call' do
       response = subject.find_by_id id: 1
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findById', 'id' => '1'}))).to have_been_made
       validate_call response
     end
 
     context 'when there is no id' do
-      it 'should raise exception' do
+      it 'raises exception' do
         expect { subject.find_by_id }.to raise_error ArgumentError
       end
     end

--- a/spec/lib/hasoffersv3_spec.rb
+++ b/spec/lib/hasoffersv3_spec.rb
@@ -1,21 +1,18 @@
-require 'spec_helper'
-
 describe HasOffersV3 do
 
   context 'singleton' do
-    it 'should use default config' do
+    it 'uses default config' do
       subject = HasOffersV3::Offer.client.configuration
       expect(subject).to eq(HasOffersV3.configuration)
     end
   end
 
   describe '#configuration' do
-    it 'should create different connections' do
-      subject = HasOffersV3.new
+    it 'creates different connections' do
       expect(subject.configuration).to_not eq(HasOffersV3.configuration)
     end
 
-    it 'should use params instead of default' do
+    it 'uses params instead of default' do
       subject = HasOffersV3.new(host: 'example.com')
       expect(subject.configuration.host).to eq('example.com')
       expect(subject.configuration.host).to_not eq(HasOffersV3::Configuration::DEFAULTS[:host])
@@ -23,10 +20,8 @@ describe HasOffersV3 do
   end
 
   context 'api' do
-    subject { HasOffersV3.new }
-
     describe '#offers' do
-      it 'should get offers for current connection' do
+      it 'gets offers for current connection' do
         offer = double('HasOffersV3::Offer')
         expect(HasOffersV3::Offer).to receive(:new).and_return(offer)
         expect(offer).to receive(:find_all)

--- a/spec/lib/offer_pixel_spec.rb
+++ b/spec/lib/offer_pixel_spec.rb
@@ -1,26 +1,22 @@
-require 'spec_helper'
-
 describe HasOffersV3::OfferPixel do
-  subject { HasOffersV3::OfferPixel.new }
-
   let(:url) { api_url 'OfferPixel' }
 
-  describe '.find_all' do
-    it 'should make a proper request call' do
+  describe '#find_all' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.find_all
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAll'}))).to have_been_made
       validate_call response
     end
 
-    it 'should contain filters by type and modified' do
+    it 'contains filters by type and modified' do
       stub_call
       response = subject.find_all(filters: {type: 'url', modified: {'GREATER_THAN' => '2015-01-01+00:00'}})
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAll', filters: { type: 'url', modified: {'GREATER_THAN' => '2015-01-01+00:00'} }}))).to have_been_made
       validate_call response
     end
 
-    it 'should sort by modified' do
+    it 'sorts by modified' do
       stub_call
       response = subject.find_all(sort: {modified: 'asc'})
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAll', sort: {modified: 'asc'}}))).to have_been_made
@@ -28,8 +24,8 @@ describe HasOffersV3::OfferPixel do
     end
   end
 
-  describe '.find_all_by_ids' do
-    it 'should make a proper request call' do
+  describe '#find_all_by_ids' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.find_all_by_ids ids: [1]
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAllByIds'}))).to have_been_made
@@ -37,14 +33,14 @@ describe HasOffersV3::OfferPixel do
     end
 
     context 'when there is no id' do
-      it 'should raise exception' do
+      it 'raises exception' do
         expect { subject.find_all_by_ids }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.find_by_id' do
-    it 'should make a proper request call' do
+  describe '#find_by_id' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.find_by_id id: [1]
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findById'}))).to have_been_made
@@ -52,14 +48,14 @@ describe HasOffersV3::OfferPixel do
     end
 
     context 'when there is no id' do
-      it 'should raise exception' do
+      it 'raises exception' do
         expect { subject.find_by_id }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.get_allowed_types' do
-    it 'should make a proper request call' do
+  describe '#get_allowed_types' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.get_allowed_types offer_id: [1]
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'getAllowedTypes'}))).to have_been_made
@@ -67,7 +63,7 @@ describe HasOffersV3::OfferPixel do
     end
 
     context 'when there is no offer_id' do
-      it 'should raise exception' do
+      it 'raises exception' do
         expect { subject.get_allowed_types }.to raise_error ArgumentError
       end
     end

--- a/spec/lib/offer_spec.rb
+++ b/spec/lib/offer_spec.rb
@@ -1,149 +1,145 @@
-require 'spec_helper'
-
 describe HasOffersV3::Offer do
-  subject { HasOffersV3::Offer.new }
-
   let(:url)  { api_url 'Offer' }
 
-  describe '.find_all' do
-    it 'should make a proper request call' do
+  describe '#find_all' do
+    it 'makes a proper request call' do
       stub_call
-      response = HasOffersV3::Offer.find_all
+      response = subject.find_all
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAll'}))).to have_been_made
       validate_call response
     end
   end
 
-  describe '.find_all_by_ids' do
-    it 'should make a proper request call' do
+  describe '#find_all_by_ids' do
+    it 'makes a proper request call' do
       stub_call
-      response = HasOffersV3::Offer.find_all_by_ids ids: [1]
+      response = subject.find_all_by_ids ids: [1]
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAllByIds'}))).to have_been_made
       validate_call response
     end
 
     context 'when there is no id' do
-      it 'should raise exception' do
-        expect { HasOffersV3::Offer.find_all_by_ids }.to raise_error ArgumentError
+      it 'raises exception' do
+        expect { subject.find_all_by_ids }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.find_all_ids_by_advertiser_id' do
-    it 'should make a proper request call' do
+  describe '#find_all_ids_by_advertiser_id' do
+    it 'makes a proper request call' do
       stub_call
-      response = HasOffersV3::Offer.find_all_ids_by_advertiser_id advertiser_id: 1
+      response = subject.find_all_ids_by_advertiser_id advertiser_id: 1
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAllIdsByAdvertiserId', 'advertiser_id' => '1'}))).to have_been_made
       validate_call response
     end
 
     context 'when there is no id' do
-      it 'should raise exception' do
-        expect { HasOffersV3::Offer.find_all_ids_by_advertiser_id }.to raise_error ArgumentError
+      it 'raises exception' do
+        expect { subject.find_all_ids_by_advertiser_id }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.find_all_ids_by_affiliate_id' do
-    it 'should make a proper request call' do
+  describe '#find_all_ids_by_affiliate_id' do
+    it 'makes a proper request call' do
       stub_call
-      response = HasOffersV3::Offer.find_all_ids_by_affiliate_id affiliate_id: 1
+      response = subject.find_all_ids_by_affiliate_id affiliate_id: 1
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findAllIdsByAffiliateId', 'affiliate_id' => '1'}))).to have_been_made
     end
   end
 
-  describe '.find_by_id' do
-    it 'should make a proper request call' do
+  describe '#find_by_id' do
+    it 'makes a proper request call' do
       stub_call
-      response = HasOffersV3::Offer.find_by_id id: 1
+      response = subject.find_by_id id: 1
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'findById', 'id' => '1'}))).to have_been_made
       validate_call response
     end
 
     context 'when there is no id' do
-      it 'should raise exception' do
-        expect { HasOffersV3::Offer.find_by_id }.to raise_error ArgumentError
+      it 'raises exception' do
+        expect { subject.find_by_id }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.get_groups' do
-    it 'should make a proper request call' do
+  describe '#get_groups' do
+    it 'makes a proper request call' do
       stub_call
-      response = HasOffersV3::Offer.get_groups id: 1
+      response = subject.get_groups id: 1
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'getGroups'}))).to have_been_made
       validate_call response
     end
 
     context 'when there is no id' do
-      it 'should raise exception' do
-        expect { HasOffersV3::Offer.get_groups }.to raise_error ArgumentError
+      it 'raises exception' do
+        expect { subject.get_groups }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.get_approved_affiliate_ids' do
+  describe '#get_approved_affiliate_ids' do
     it 'makes a proper API request' do
       stub_call
-      response = HasOffersV3::Offer.get_approved_affiliate_ids id: 1
+      response = subject.get_approved_affiliate_ids id: 1
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'getApprovedAffiliateIds'}))).to have_been_made
       validate_call response
     end
 
     context 'when id parameter is missed' do
       it 'raises an exception' do
-        expect {  HasOffersV3::Offer.get_approved_affiliate_ids }.to raise_error ArgumentError
+        expect { subject.get_approved_affiliate_ids }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.set_payout' do
-    it 'should make a proper request call' do
+  describe '#set_payout' do
+    it 'makes a proper request call' do
       stub_call
-      response = HasOffersV3::Offer.set_payout id: 1, affiliate_id: 321
+      response = subject.set_payout id: 1, affiliate_id: 321
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'setPayout'}))).to have_been_made
       validate_call response
     end
 
     context 'when the id and/or affiliate id parameters are missing' do
       it 'raises an exception' do
-        expect {  HasOffersV3::Offer.set_payout }.to raise_error ArgumentError
+        expect { subject.set_payout }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.set_tier_payout' do
-    it 'should make a proper request call' do
+  describe '#set_tier_payout' do
+    it 'makes a proper request call' do
       stub_call
-      response = HasOffersV3::Offer.set_tier_payout id: 1, affiliate_tier_id: 2
+      response = subject.set_tier_payout id: 1, affiliate_tier_id: 2
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'setTierPayout'}))).to have_been_made
       validate_call response
     end
 
     context 'when the id and/or affiliate tier id parameters are missing' do
       it 'raises an exception' do
-        expect {  HasOffersV3::Offer.set_tier_payout }.to raise_error ArgumentError
+        expect { subject.set_tier_payout }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.remove_payout' do
-    it 'should make a proper request call' do
+  describe '#remove_payout' do
+    it 'makes a proper request call' do
       stub_call
-      response = HasOffersV3::Offer.remove_payout id: 1, affiliate_id: 321
+      response = subject.remove_payout id: 1, affiliate_id: 321
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'removePayout'}))).to have_been_made
       validate_call response
     end
 
     context 'when the id and/or affiliate id parameters are missing' do
       it 'raises an exception' do
-        expect {  HasOffersV3::Offer.remove_payout }.to raise_error ArgumentError
+        expect { subject.remove_payout }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.generate_tracking_link' do
-    it 'should make a proper request call' do
+  describe '#generate_tracking_link' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.generate_tracking_link offer_id: 1, affiliate_id: 123
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'generateTrackingLink','offer_id' => '1',
@@ -152,24 +148,24 @@ describe HasOffersV3::Offer do
     end
 
     context 'when required params are missing' do
-      it 'should fail without offer_id' do
+      it 'fails without offer_id' do
         expect { subject.generate_tracking_link affiliate_id: 1}.to raise_error ArgumentError
       end
-      it 'should fail without affiliate_id' do
+      it 'fails without affiliate_id' do
         expect { subject.generate_tracking_link offer_id: 10 }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.get_tier_payouts' do
-    it 'should make a proper request call' do
+  describe '#get_tier_payouts' do
+    it 'makes a proper request call' do
       stub_call
       response = subject.get_tier_payouts id: 1
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'getTierPayouts','id' => '1'}))).to have_been_made
       validate_call response
     end
 
-    it 'should fail without id' do
+    it 'fails without id' do
       expect { subject.get_tier_payouts }.to raise_error ArgumentError
     end
   end

--- a/spec/lib/raw_log_spec.rb
+++ b/spec/lib/raw_log_spec.rb
@@ -1,71 +1,67 @@
-require 'spec_helper'
-
 describe HasOffersV3::RawLog do
-  subject { HasOffersV3::RawLog.new }
-
   let(:url)  { Regexp.new api_url('RawLog') }
 
   before :each do
     stub_call :get
   end
 
-  describe '.get_download_link' do
-    it 'should make a proper request call' do
+  describe '#get_download_link' do
+    it 'makes a proper request call' do
       response = subject.get_download_link log_type: 'clicks', log_filename: 'xxx'
       expect(a_request(:get, url).with(query: hash_including({'Method' => 'getDownloadLink'}))).to have_been_made
       validate_call response
     end
 
     context 'when there is no log_type' do
-      it 'it should raise an exception' do
+      it 'raises an exception' do
         expect { subject.get_download_link log_filename: 'xxx' }.to raise_error ArgumentError
       end
     end
 
     context 'when there is no log_filename' do
-      it 'it should raise an exception' do
+      it 'raises an exception' do
         expect { subject.get_download_link log_type: 'clicks' }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.get_log_expirations' do
-    it 'should make a proper request call' do
+  describe '#get_log_expirations' do
+    it 'makes a proper request call' do
       response = subject.get_log_expirations
       expect(a_request(:get, url).with(query: hash_including({'Method' => 'getLogExpirations'}))).to have_been_made
       validate_call response
     end
   end
 
-  describe '.list_date_dirs' do
-    it 'should make a proper request call' do
+  describe '#list_date_dirs' do
+    it 'makes a proper request call' do
       response = subject.list_date_dirs log_type: 'clicks'
       expect(a_request(:get, url).with(query: hash_including({'Method' => 'listDateDirs'}))).to have_been_made
       validate_call response
     end
 
     context 'when there is no log_type' do
-      it 'it should raise an exception' do
+      it 'raises an exception' do
         expect { subject.list_date_dirs }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '.list_logs' do
-    it 'should make a proper request call' do
+  describe '#list_logs' do
+    it 'makes a proper request call' do
       response = subject.list_logs log_type: 'clicks', date_dir: '20140101'
       expect(a_request(:get, url).with(query: hash_including({'Method' => 'listLogs'}))).to have_been_made
       validate_call response
     end
 
     context 'when there is no log_type' do
-      it 'it should raise an exception' do
+      it 'raises an exception' do
         expect { subject.list_logs date_dir: '20140101' }.to raise_error ArgumentError
       end
     end
 
     context 'when there is no date_dir' do
-      it 'it should raise an exception' do
+      it 'raises an exception' do
         expect { subject.list_logs log_type: 'clicks' }.to raise_error ArgumentError
       end
     end

--- a/spec/lib/report_spec.rb
+++ b/spec/lib/report_spec.rb
@@ -1,61 +1,25 @@
-require 'spec_helper'
-
 describe HasOffersV3::Report do
-  subject { HasOffersV3::Report.new }
   let(:url)  { api_url 'Report' }
 
-  describe '.get_conversions' do
+  describe '#get_conversions' do
     before(:each) { stub_call }
 
-    it 'should make a proper request call' do
+    it 'makes a proper request call' do
       response = subject.get_conversions
       expect(a_request(:post, url).with(body: hash_including({'Method' => 'getConversions'}))).to have_been_made
       validate_call response
     end
   end
 
-  describe '.getConversions' do
-    before(:each) { stub_call }
-
-    it 'should make a proper request call' do
-      response = subject.get_conversions
-      expect(a_request(:post, url).with(body: hash_including({'Method' => 'getConversions'}))).to have_been_made
-      validate_call response
-    end
-
-    it 'should call find_all method' do
-      expect(subject).to receive(:get_conversions).with({test: 1})
-      subject.get_conversions test: 1
-    end
-  end
-
-  describe '.get_mod_summary_logs' do
+  describe '#get_mod_summary_logs' do
     let(:url)  { Regexp.new api_url('Report') }
 
     before(:each) { stub_call :get }
 
-    it 'should make a proper request call' do
+    it 'makes a proper request call' do
       response = subject.get_mod_summary_logs
       expect(a_request(:get, url).with(query: hash_including({'Method' => 'getModSummaryLogs'}))).to have_been_made
       validate_call response
     end
-  end
-
-  describe '.getModSummaryLogs' do
-    let(:url)  { Regexp.new api_url('Report') }
-
-    before(:each) { stub_call :get }
-
-    it 'should make a proper request call' do
-      response = subject.get_mod_summary_logs
-      expect(a_request(:get, url).with(query: hash_including({'Method' => 'getModSummaryLogs'}))).to have_been_made
-      validate_call response
-    end
-
-    it 'should call find_all method' do
-      expect(subject).to receive(:get_mod_summary_logs).with({test: 1})
-      subject.get_mod_summary_logs test: 1
-    end
-
   end
 end


### PR DESCRIPTION
The follow commits applying [RSpec guideline concepts](http://betterspecs.org) in HasOffersV3 test suite, besides update RSpec to latest version.

- Update RSpec to version 3.4;
- Replace old should syntax by expect syntax;
- Move `spec_helper` requirement to .rspec config file;
- Use RSpec `subject`;
- Use the third person in the present tense to describe tests;
- Remove duplicated tests.
