### PR TITLE
Custom errors functionality (feature branch to the master)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ tmp
 .DS_Store
 *.swp
 .ruby-version
+.ruby-gemset
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.6.0
-- [#60] Added configurable (via `config.raise_errors = true`) raising of internal exceptions (`HasOffersV3::Error` and its descendants) on various API error conditions.  Incompatible changes: JSON parsing error now raises a `HasOffersV3::ParseError` that wraps the original error from a particular JSON driver used. (@vittorius)
+- [#61] Added configurable (via `config.raise_errors = true`) raising of internal exceptions (`HasOffersV3::Error` and its descendants) on various API error conditions.  Incompatible changes: JSON parsing error now raises a `HasOffersV3::ParseError` that wraps the original error from a particular JSON driver used. (@vittorius)
 
 # 0.5.5
 - [#58] Added `AdvertiserBilling::findAllInvoicesByIds`, `AffiliateBilling::findAllInvoicesByIds` methods. (@kamil89)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.6.0
+- [#60] Added configurable (via `config.raise_errors = true`) raising of internal exceptions (`HasOffersV3::Error` and its descendants) on various API error conditions.  Incompatible changes: JSON parsing error now raises a `HasOffersV3::ParseError` that wraps the original error from a particular JSON driver used. (@vittorius)
+
 # 0.5.5
 - [#58] Added `AdvertiserBilling::findAllInvoicesByIds`, `AffiliateBilling::findAllInvoicesByIds` methods. (@kamil89)
 - [#59] Added `Advertiser::getSingupAnswers` and `Affiliate::getSingupAnswers` methods. (@kamil89)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ### Overview
 
 [![Build status](https://api.travis-ci.org/applift/hasoffersv3.png?branch=master)](http://travis-ci.org/applift/hasoffersv3)
+[![Gem Version](https://badge.fury.io/rb/hasoffersv3.svg)](https://badge.fury.io/rb/hasoffersv3)
 
 ### Synopsis
 
@@ -28,7 +29,7 @@ HasOffersV3.configure do |config|
   config.api_key      = 'Your HasOffers API Key'
   config.network_id   = 'Your HasOffers Network ID'
   config.read_timeout = 10
-  config.raise_errors = true # add this if you want the hasoffersv3 to raise errors upon detected API error messages in responses
+  config.raise_errors = true # add this if you want the hasoffersv3 to raise errors upon detected API error messages in responses; defaults to `false`
 
   # Optionally configure a proxy:
   config.proxy_host   = 'yourproxy.com'
@@ -72,6 +73,10 @@ HasOffersV3::Advertiser.signup({
   return_object: 1
 })
 ```
+
+### Error handling
+
+If `config.raise_errors` was set to `true`, the `hasoffersv3` will raise internal exceptions when error occurs at protocol or business logic level. See the [`HasOffersV3::Error`](https://github.com/applift/hasoffersv3/blob/master/lib/hasoffersv3/error.rb) and its descendants' definitions for more comments and details.
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ HasOffersV3.configure do |config|
   config.api_key      = 'Your HasOffers API Key'
   config.network_id   = 'Your HasOffers Network ID'
   config.read_timeout = 10
+  config.raise_errors = true # add this if you want the hasoffersv3 to raise errors upon detected API error messages in responses
 
   # Optionally configure a proxy:
   config.proxy_host   = 'yourproxy.com'

--- a/lib/hasoffersv3/api_error.rb
+++ b/lib/hasoffersv3/api_error.rb
@@ -2,6 +2,7 @@
 require 'hasoffersv3/error'
 
 class HasOffersV3
+  # Any error emitted at business logic level of the HasOffersV3 API that is not fatal but tells that a particular operation cannot be performed.
   class APIError < ResponseError
     class << self
       def from_response(response)

--- a/lib/hasoffersv3/api_error.rb
+++ b/lib/hasoffersv3/api_error.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'hasoffersv3/error'
+
+class HasOffersV3
+  class APIError < ResponseError
+    class << self
+      def from_response(response)
+        error_class_chain.each do |error_class|
+          err_msg = error_class.detect(response)
+          break error_class.new(err_msg, response) if err_msg
+        end
+      end
+
+      protected
+
+      def error_class_chain
+        # the order is important, more "blocker-like" errors go before "lax" ones; don't forget to add any new error classes to this chain
+        @error_class_chain ||= [IPNotWhitelistedError, MissingParamError, FieldError, InternalError, UnknownError]
+      end
+    end
+  end
+
+  class IPNotWhitelistedError < APIError
+    def self.detect(response)
+      response.error_messages.grep(/IP \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3} is not white-listed/).first
+    end
+  end
+
+  class MissingParamError < APIError
+    def self.detect(response)
+      response.error_messages.grep(/Missing required argument/).first
+    end
+  end
+
+  class FieldError < APIError
+    def self.detect(response)
+      response.error_messages.grep(/Field '.*' does not exist or is not allowed to be used./).first
+    end
+  end
+
+  class InternalError < APIError
+    def self.detect(response)
+      # E.g. "There was a database error with the trackable id [SE-5888e90b944af]. Contact support for more assistance."
+      response.error_messages.grep(/error with the trackable id/).first
+    end
+  end
+
+  class UnknownError < APIError
+    def self.detect(response)
+      response.error_messages.first
+    end
+  end
+end

--- a/lib/hasoffersv3/configuration.rb
+++ b/lib/hasoffersv3/configuration.rb
@@ -20,6 +20,7 @@ class HasOffersV3
       network_id: '',
       api_key: '',
       json_driver: self.default_json_driver,
+      raise_errors: false,
       logger: nil,
       proxy_host: nil,
       proxy_port: nil,

--- a/lib/hasoffersv3/error.rb
+++ b/lib/hasoffersv3/error.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'active_support/core_ext/module/delegation'
+
+class HasOffersV3
+  class Error < StandardError; end
+
+  class ResponseError < Error
+    attr_reader :response
+    delegate :http_status_code, :http_message, :http_headers, to: :response
+
+    def initialize(message, response)
+      super(message)
+      @response = response
+    end
+  end
+
+  class ParseError < ResponseError; end
+
+  class HTTPError < ResponseError
+    def self.from_response(response)
+      new("HTTP error: #{response.http_message}", response)
+    end
+  end
+end

--- a/lib/hasoffersv3/error.rb
+++ b/lib/hasoffersv3/error.rb
@@ -14,8 +14,12 @@ class HasOffersV3
     end
   end
 
+  # An error caught when parsing the JSON response body got from API endpoint.
+  # Wraps the original JSON driver error emitted.
+  # Raised always (does not depend on the config settings).
   class ParseError < ResponseError; end
 
+  # Any HTTP error that has occurred during the call to the API endpoint (gateway timeout, internal server error etc.)
   class HTTPError < ResponseError
     def self.from_response(response)
       new("HTTP error: #{response.http_message}", response)

--- a/lib/hasoffersv3/response.rb
+++ b/lib/hasoffersv3/response.rb
@@ -3,14 +3,27 @@ class HasOffersV3
     attr_reader :body, :http_status_code, :http_message, :http_headers
 
     def initialize(response, json=default_json_driver)
-      @body             = json.load(response.body.to_s)
+      begin
+        @body = json.load(response.body.to_s)
+      rescue
+        raise ParseError.new('Error parsing response body, examine the `cause` property for details', response)
+      end
+
       @http_status_code = response.code
       @http_message     = response.message
       @http_headers     = response.to_hash
     end
 
     def success?
-      @http_status_code.to_s == '200' and status == 1
+      http_ok? && status_ok?
+    end
+
+    def http_ok?
+      @http_status_code.to_s == '200'
+    end
+
+    def status_ok?
+      status == 1
     end
 
     def status

--- a/lib/hasoffersv3/version.rb
+++ b/lib/hasoffersv3/version.rb
@@ -1,3 +1,3 @@
 class HasOffersV3
-  VERSION = '0.5.5'
+  VERSION = '0.6.0'
 end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -1,30 +1,150 @@
+# frozen_string_literal: true
+
 describe HasOffersV3::Client do
   let(:config) { HasOffersV3::Configuration.new }
-  subject {  HasOffersV3::Client.new(config) }
+  let(:client) { HasOffersV3::Client.new(config) }
+  subject { client }
 
   describe '#new_http' do
-
     context 'when configuration proxy_host is present' do
-
-      let(:config) {
+      let(:config) do
         result = HasOffersV3::Configuration.new
         result.proxy_host = 'proxy.com'
         result.proxy_port = '8080'
         result
-      }
+      end
 
       it 'generates a connection with proxy' do
         http_client = subject.new_http(URI('http://hasoffers.com:9300/'))
         expect(http_client.proxyaddr).to eq('proxy.com')
         expect(http_client.proxyport).to eq('8080')
       end
-
     end
+  end
 
+  describe '#request' do
+    context 'raising errors' do
+      let(:raise_errors) { true }
+      let(:config) { HasOffersV3::Configuration.new(raise_errors: raise_errors) }
+      let(:url) { api_url 'Advertiser' }
+      let(:response_body) { JSON.load(default_return[:body]) } # it's more convenient for us to have response_body as a Ruby object
+      let(:status) { default_return[:status] }
+      let(:headers) { {} }
+      let(:response) do
+        {
+          body: JSON.dump(response_body),
+          status: status,
+          headers: headers
+        }
+      end
+      let(:http_method) { :post }
+
+      before { stub_call(http_method, response) }
+
+      subject { client.request(http_method, 'Advertiser', 'findAll', {}) }
+
+      shared_examples 'does not raise errors when configured to not raise errors' do
+        let(:raise_errors) { false }
+
+        it 'does not raise errors' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'no errors' do
+        it 'does not raise error if no error messages were detected' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'HTTP errors' do
+        let(:response_body) { nil }
+        let(:headers) { { 'Content-Length' => 0, 'Connection' => 'Close' } }
+        let(:status) { [504, 'GATEWAY_TIMEOUT'] }
+
+        it 'raises an appropriate error when HTTP failure detected' do
+          expect { subject }.to raise_error do |error|
+            expect(error).to be_a HasOffersV3::HTTPError
+            expect(error).to have_attributes(
+                               message: 'HTTP error: GATEWAY_TIMEOUT',
+                               http_status_code: '504',
+                               http_message: 'GATEWAY_TIMEOUT',
+                               http_headers: {
+                                 'content-length' => ['0'],
+                                 'connection' => ['Close']
+                               }
+                             )
+          end
+        end
+
+        it_behaves_like 'does not raise errors when configured to not raise errors'
+      end
+
+      context 'API errors' do
+        shared_examples 'API error is detected and raised' do
+          let(:response_body) do
+            {
+              'response' => {
+                'status' => -1,
+                'httpStatus' => 200,
+                'data' => '',
+                'errors' => [{'publicMessage' => error_message }],
+                'errorMessage' => error_message
+              }
+            }
+          end
+
+          it 'raises an appropriate error when such an error detected' do
+            expect { subject }.to raise_error(error_class, error_message)
+          end
+
+          it_behaves_like 'does not raise errors when configured to not raise errors'
+        end
+
+        context 'IP is not whitelisted' do
+          let(:error_message) { 'IP 178.161.91.191 is not white-listed. Please enable it in the application, Support => API' }
+          let(:error_class) { HasOffersV3::IPNotWhitelistedError }
+
+          it_behaves_like 'API error is detected and raised'
+        end
+
+        context 'parameter missing' do
+          subject { client.request(http_method, 'Advertiser', 'findById', {}) }
+
+          let(:error_message) { 'Missing required argument: id' }
+          let(:error_class) { HasOffersV3::MissingParamError }
+
+          it_behaves_like 'API error is detected and raised'
+        end
+
+        context 'field error' do
+          let(:url) { api_url 'Report' }
+          subject { client.request(http_method, 'Report', 'getStats', { 'fields[]' => 'Offer.nam' }) }
+
+          let(:error_message) { "Field 'Offer.nam' does not exist or is not allowed to be used." }
+          let(:error_class) { HasOffersV3::FieldError }
+
+          it_behaves_like 'API error is detected and raised'
+        end
+
+        context 'internal error' do
+          let(:error_message) { 'There was a database error with the trackable id [SE-5888e90b944af]. Contact support for more assistance.' }
+          let(:error_class) { HasOffersV3::InternalError }
+
+          it_behaves_like 'API error is detected and raised'
+        end
+
+        context 'unknown error' do
+          let(:error_message) { 'Something went wrong.' }
+          let(:error_class) { HasOffersV3::UnknownError }
+
+          it_behaves_like 'API error is detected and raised'
+        end
+      end
+    end
   end
 
   describe '#base_uri' do
-
     let(:configuration_to_default_host) { HasOffersV3::Configuration.new }
     let(:config_for_proxy) {
       result = HasOffersV3::Configuration.new
@@ -39,7 +159,5 @@ describe HasOffersV3::Client do
       proxy_connection = HasOffersV3::Client.new(config_for_proxy)
       expect(proxy_connection.base_uri).to eq('https://api.applift.com/v3')
     end
-
   end
-
 end

--- a/spec/lib/response_spec.rb
+++ b/spec/lib/response_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'hasoffersv3/error'
+
+describe HasOffersV3::Response do
+  describe '#initialize' do
+    it 'raises an appropriate error on malformed response body' do
+      expect { described_class.new('"') }.to(
+        raise_error(HasOffersV3::ParseError, 'Error parsing response body, examine the `cause` property for details')
+      )
+    end
+  end
+end


### PR DESCRIPTION
The idea is to extend the error reporting functionality for the benefit of the applications using the gem. It will be much easier for the developers of such applications to understand the precise error and its context from the exception being raised.

The custom errors will be raised only if `raise_errors: true` setting is provided for the `Configuration` object.

**This is a pull-request from a feature branch to the master.** The feature branch was already reviewed and accepted in https://github.com/applift/hasoffersv3/pull/60.